### PR TITLE
feat(NWR-121): implement API endpoint for editing transactions

### DIFF
--- a/src/transaction/dto/ update-transaction.dto.ts
+++ b/src/transaction/dto/ update-transaction.dto.ts
@@ -1,0 +1,15 @@
+import { PartialType } from "@nestjs/mapped-types";
+import { CreateTransactionDto } from "./create-transaction.dto";
+import { IsDateString, IsOptional } from "class-validator";
+import { ApiProperty } from "@nestjs/swagger";
+
+export class UpdateTransactionDto extends PartialType(CreateTransactionDto) {
+  @ApiProperty({
+    description: "The updated date of the transaction",
+    example: "2024-09-20T00:00:00.000Z",
+    required: false,
+  })
+  @IsOptional()
+  @IsDateString()
+  date?: string; // Asegúrate de que el tipo de dato coincida con el modelo de Prisma (DateTime)
+}

--- a/src/transaction/transaction.controller.ts
+++ b/src/transaction/transaction.controller.ts
@@ -6,6 +6,7 @@ import { ApiOperation, ApiResponse, ApiTags, ApiBearerAuth } from "@nestjs/swagg
 import { IAuthenticatedRequest } from "../interfaces/auth/authenticated-request.interface";
 import { Roles } from "../auth/roles.decorator";
 import { CreateTransactionDto } from "./dto/create-transaction.dto";
+import { UpdateTransactionDto } from "./dto/ update-transaction.dto";
 
 @ApiTags("Transaction")
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -49,5 +50,19 @@ export class TransactionController {
   async createTransaction(@Req() req: IAuthenticatedRequest, @Body() createTransactionDto: CreateTransactionDto) {
     const userId = req.user.userId;
     return this.transactionService.createTransaction(userId, createTransactionDto);
+  }
+
+  @Put(":transaction_id")
+  @ApiOperation({
+    summary: "Update an existing transaction",
+    description: "Allows the authenticated user to update any field of a transaction they own.",
+  })
+  @ApiResponse({ status: 200, description: "Transaction updated successfully." })
+  @ApiResponse({ status: 400, description: "Bad Request" })
+  @ApiResponse({ status: 403, description: "Forbidden: User is not the owner of the transaction" })
+  @ApiResponse({ status: 404, description: "Transaction not found" })
+  async updateTransaction(@Param("transaction_id", ParseIntPipe) transactionId: number, @Req() req: IAuthenticatedRequest, @Body() updateTransactionDto: UpdateTransactionDto) {
+    const userId = req.user.userId; // Obtiene el userId del token decodificado
+    return this.transactionService.updateTransaction(transactionId, userId, updateTransactionDto);
   }
 }


### PR DESCRIPTION
- Developed `PUT /transactions/{transaction_id}` endpoint to update transaction details, including `amount` and date, if the user is the owner.
- Added permission validation to prevent edits by non-owners.
- Implemented clear error messages for validation failures.