### PR TITLE
feat(NWR-122): implement API endpoint for deleting transactions

### DIFF
--- a/src/pipes/custom-parse-int.pipe.ts
+++ b/src/pipes/custom-parse-int.pipe.ts
@@ -1,0 +1,14 @@
+import { PipeTransform, Injectable, BadRequestException } from "@nestjs/common";
+
+@Injectable()
+export class CustomParseIntPipe implements PipeTransform<string | number, number> {
+  transform(value: string | number): number {
+    const val = typeof value === "string" ? parseInt(value, 10) : value;
+
+    if (isNaN(val)) {
+      throw new BadRequestException("Validation failed (numeric string or number is expected)");
+    }
+
+    return val;
+  }
+}

--- a/src/transaction/transaction.controller.ts
+++ b/src/transaction/transaction.controller.ts
@@ -7,6 +7,7 @@ import { IAuthenticatedRequest } from "../interfaces/auth/authenticated-request.
 import { Roles } from "../auth/roles.decorator";
 import { CreateTransactionDto } from "./dto/create-transaction.dto";
 import { UpdateTransactionDto } from "./dto/ update-transaction.dto";
+import { CustomParseIntPipe } from "../pipes/custom-parse-int.pipe";
 
 @ApiTags("Transaction")
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -64,5 +65,18 @@ export class TransactionController {
   async updateTransaction(@Param("transaction_id", ParseIntPipe) transactionId: number, @Req() req: IAuthenticatedRequest, @Body() updateTransactionDto: UpdateTransactionDto) {
     const userId = req.user.userId; // Obtiene el userId del token decodificado
     return this.transactionService.updateTransaction(transactionId, userId, updateTransactionDto);
+  }
+
+  @Delete(":transaction_id")
+  @ApiOperation({
+    summary: "Delete an existing transaction",
+    description: "Allows the authenticated user to delete a transaction they own.",
+  })
+  @ApiResponse({ status: 200, description: "Transaction deleted successfully." })
+  @ApiResponse({ status: 403, description: "Forbidden: User is not the owner of the transaction" })
+  @ApiResponse({ status: 404, description: "Transaction not found" })
+  async deleteTransaction(@Param("transaction_id", CustomParseIntPipe) transactionId: number, @Req() req: IAuthenticatedRequest) {
+    const userId = req.user.userId; // Obtiene el userId del token decodificado
+    return this.transactionService.deleteTransaction(transactionId, userId);
   }
 }

--- a/src/transaction/transaction.service.ts
+++ b/src/transaction/transaction.service.ts
@@ -269,4 +269,34 @@ export class TransactionService {
       transaction: updatedTransaction,
     };
   }
+
+  /**
+   * Deletes a transaction if the user is the owner.
+   * @param transactionId - The ID of the transaction to delete.
+   * @param userId - The ID of the user attempting the deletion.
+   * @returns A confirmation message on successful deletion.
+   * @throws NotFoundException if the transaction does not exist.
+   * @throws ForbiddenException if the user is not the owner of the transaction.
+   */
+  async deleteTransaction(transactionId: number, userId: number) {
+    const transaction = await this.prisma.transaction.findUnique({
+      where: { transaction_id: transactionId },
+    });
+
+    if (!transaction) {
+      throw new NotFoundException(`Transaction with ID ${transactionId} not found`);
+    }
+
+    if (transaction.user_id !== userId) {
+      throw new ForbiddenException(`You do not have permission to delete this transaction`);
+    }
+
+    await this.prisma.transaction.delete({
+      where: { transaction_id: transactionId },
+    });
+
+    return {
+      message: "Transaction deleted successfully",
+    };
+  }
 }


### PR DESCRIPTION
- Developed `DELETE /transactions/{transaction_id}` endpoint to allow users to delete specific transactions.
- Implemented ownership verification before allowing transaction deletion.
- Added response handling for successful deletion confirmation or error message if deletion fails.